### PR TITLE
Fix range calculation for NPCs

### DIFF
--- a/scripts/ranged_attacks.lua
+++ b/scripts/ranged_attacks.lua
@@ -413,6 +413,16 @@ function getWeaponRanges5e(rActor, sRanged, sWeaponName)
 				if ( nodeName:lower() == sWeaponName:lower() ) then					
 					local description = DB.getText(nodeChild .. '.desc');										
 					local rangeText = '';
+						
+					-- Spell action version 1
+					-- this exception is needed as some modules have a slightly different range entries
+					-- where spell entries on NPCs are put under actions, and only one range is available
+					-- string input ex. 'Ranged Spell Attack: +5 to hit, range 150 ft., one target. Hit: 10 (3d6) fire damage. ...'		
+					rangeText = string.match(description, "range%s%d*");
+					if rangeText ~= nil then					
+						medRange = string.sub(rangeText, 7, string.len(rangeText));
+						maxRange = medRange;							
+					end	
 
 					-- Weapon version 1		
 					-- search for 'range * ft', return range as substring, split substring in two (medium/max range)					
@@ -436,16 +446,6 @@ function getWeaponRanges5e(rActor, sRanged, sWeaponName)
 						medRange = string.sub(rangeText, 7, index - 4);
 						maxRange = string.sub(rangeText, index + 1, string.len(rangeText));	
 					end
-						
-					-- Spell action version 1
-					-- this exception is needed as some modules have a slightly different range entries
-					-- where spell entries on NPCs are put under actions, and only one range is available
-					-- string input ex. 'Ranged Spell Attack: +5 to hit, range 150 ft., one target. Hit: 10 (3d6) fire damage. ...'		
-					rangeText = string.match(description, "range%s%d*");
-					if rangeText ~= nil then					
-						medRange = string.sub(rangeText, 7, string.len(rangeText));
-						maxRange = medRange;							
-					end	
 				end								
 			end			
 


### PR DESCRIPTION
The "Spell action version 1" variant was overriding the "Weapon version 1" one, causing the maximum range to be ignored.